### PR TITLE
Refactor env parser to a more stateless fashion

### DIFF
--- a/elyra/contents/__init__.py
+++ b/elyra/contents/__init__.py
@@ -13,5 +13,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from .file_parser import FileParser, NotebookFileParser, PythonFileParser
+from .parser import FileReader, NotebookReader, PythonScriptParser, RScriptParser, ContentParser
 from .handlers import FileParserHandler

--- a/elyra/contents/tests/__init__.py
+++ b/elyra/contents/tests/__init__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from ..file_parser import FileParser
+from elyra.contents.parser import ContentParser

--- a/elyra/contents/tests/test_content_parser.py
+++ b/elyra/contents/tests/test_content_parser.py
@@ -16,81 +16,81 @@
 import os
 import pytest
 
-from ..file_parser import FileParser
+from elyra.contents.parser import ContentParser
 
 
 def parse(filepath):
-    operation_filepath = os.path.join(os.path.dirname(__file__), filepath)
+    absolute_filepath = os.path.join(os.path.dirname(__file__), filepath)
 
-    operation = FileParser.get_instance(filepath=operation_filepath)
-    return operation.get_resources()
+    parser = ContentParser()
+    return parser.parse(absolute_filepath)
 
 
-def _get_variable_names(model):
-    return list(model['env_list'].keys())
+def _get_variable_names(properties):
+    return list(properties['env_list'].keys())
 
 
 def test_python_notebook():
     expected_variable_names = ['VAR1', 'VAR2', 'VAR3', 'VAR4', 'VAR5', 'VAR6', 'VAR7', 'VAR8']
-    model = parse("resources/parse_python.ipynb")
+    properties = parse("resources/parse_python.ipynb")
 
-    variable_names = _get_variable_names(model)
+    variable_names = _get_variable_names(properties)
     assert variable_names == expected_variable_names
 
 
 def test_r_notebook():
     expected_variable_names = ['VAR1', 'VAR2', 'VAR3', 'VAR4', 'VAR5', 'VAR6']
-    model = parse("resources/parse_r.ipynb")
+    properties = parse("resources/parse_r.ipynb")
 
-    variable_names = _get_variable_names(model)
+    variable_names = _get_variable_names(properties)
     assert variable_names == expected_variable_names
 
 
 def test_python_script():
     expected_variable_names = ['VAR1', 'VAR2', 'VAR3', 'VAR4', 'VAR5', 'VAR6', 'VAR7', 'VAR8']
-    model = parse("resources/parse.py")
+    properties = parse("resources/parse.py")
 
-    variable_names = _get_variable_names(model)
+    variable_names = _get_variable_names(properties)
     assert variable_names == expected_variable_names
 
 
 def test_r_script():
     expected_variable_names = ['VAR1', 'VAR2', 'VAR3', 'VAR4', 'VAR5', 'VAR6']
-    model = parse("resources/parse.r")
+    properties = parse("resources/parse.r")
 
-    variable_names = _get_variable_names(model)
+    variable_names = _get_variable_names(properties)
     assert variable_names == expected_variable_names
 
 
 def test_empty_python_notebook():
     expected_variable_names = []
-    model = parse("resources/parse_python_empty.ipynb")
+    properties = parse("resources/parse_python_empty.ipynb")
 
-    variable_names = _get_variable_names(model)
+    variable_names = _get_variable_names(properties)
     assert variable_names == expected_variable_names
 
 
 def test_empty_r_notebook():
     expected_variable_names = []
-    model = parse("resources/parse_r_empty.ipynb")
+    properties = parse("resources/parse_r_empty.ipynb")
 
-    variable_names = _get_variable_names(model)
+    variable_names = _get_variable_names(properties)
     assert variable_names == expected_variable_names
 
 
 def test_empty_python_script():
     expected_variable_names = []
-    model = parse("resources/parse_empty.py")
+    properties = parse("resources/parse_empty.py")
 
-    variable_names = _get_variable_names(model)
+    variable_names = _get_variable_names(properties)
     assert variable_names == expected_variable_names
 
 
 def test_empty_r_script():
     expected_variable_names = []
-    model = parse("resources/parse_empty.r")
+    properties = parse("resources/parse_empty.r")
 
-    variable_names = _get_variable_names(model)
+    variable_names = _get_variable_names(properties)
     assert variable_names == expected_variable_names
 
 
@@ -114,17 +114,17 @@ def test_file_is_not_directory():
 
 def test_no_kernel():
     expected_variable_names = []
-    model = parse("resources/parse_no_kernel.ipynb")
+    properties = parse("resources/parse_no_kernel.ipynb")
 
-    variable_names = _get_variable_names(model)
+    variable_names = _get_variable_names(properties)
     assert variable_names == expected_variable_names
 
 
 def test_parser_not_set():
     expected_variable_names = []
-    model = parse("resources/parse_no_language.ipynb")
+    properties = parse("resources/parse_no_language.ipynb")
 
-    variable_names = _get_variable_names(model)
+    variable_names = _get_variable_names(properties)
     assert variable_names == expected_variable_names
 
 


### PR DESCRIPTION
Refactor content parser into a more stateless implementation and do some renames to distinguish of the stateful reader and stateless parser. Also, implement some separation of concerns such as removing the understanding of server configurations (e.g. root-dir) from parser/reader and making responsibility of the handler to provide an absolute path to the parser/reader.

Note that, there is only minor change on tests, so functionality should remain the same. 

Please let me know your thoughts
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

